### PR TITLE
Finalize devnet 2 specification targets

### DIFF
--- a/breakout-rooms/leanConsensus/pq-interop/pq-devnet-2.md
+++ b/breakout-rooms/leanConsensus/pq-interop/pq-devnet-2.md
@@ -21,7 +21,7 @@
 | leanSpec      | [leanEthereum/leanSpec@fbbacbe](https://github.com/leanEthereum/leanSpec/tree/fbbacbea4545be870e25e3c00a90fc69e019c5bb) | |
 | leanSig | [leanEthereum/leanSig@ae12a5f](https://github.com/leanEthereum/leanSig/tree/ae12a5feb25d917c42b6466444ebd56ec115a629) | |
 | leanMultisig | [leanEthereum/leanMultisig@4543620](https://github.com/leanEthereum/leanMultisig/tree/4543620b8e33c16112dcf1fff7f250344913a729) |  |
-| leanMetrics   | [leanEthereum/leanMetrics@7fac4cc](https://github.com/leanEthereum/leanMetrics/tree/7fac4cc3e3d0bcc5e498f6abd74c80c8245f5591) | |
+| leanMetrics   | [leanEthereum/leanMetrics@3b32b30](https://github.com/leanEthereum/leanMetrics/tree/3b32b300cca5ed7a7a2b3f142273fae9dbc171bf) | |
 
 ## Configurations
 


### PR DESCRIPTION
# problem

Devnet 2 still has rolling targets, devnet 3 speccing is starting very shortly so we should finalize devnet 2 so clients can finalize their implementations and we can began devnet's

# solution

Finalize the spec, the tooling can be finalized in a different PR once we figure that stuff out